### PR TITLE
Us26 admin merchant update

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,4 +6,23 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:id])
+    if @merchant.update(merchant_params)
+      redirect_to "/admin/merchants/#{@merchant.id}"
+      flash[:notice] = "Merchant #{@merchant.id} has been successfully updated"
+    else
+      redirect_to "/admin/merchants/#{@merchant.id}/edit"
+    end
+  end
+
+  private
+  def merchant_params
+    params.require(:merchant).permit(:name)
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Merchant <%= @merchant.id %></h1>
+<%= form_with model: @merchant, url: "/admin/merchants/#{@merchant.id}", method: "patch", local: true do |form| %>
+  <%= form.label :name, "Name:" %>
+  <%= form.text_field :name %>
+  <%= form.submit "Update Merchant" %>
+<% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,5 @@
+<% flash.each do |type, message| %>
+  <%= message %>
+<% end %>
 <h1><%= "#{@merchant.name}" %></h1>
+<%= link_to "Edit #{@merchant.name}", "/admin/merchants/#{@merchant.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
 
   get "/admin/merchants", to: "admin/merchants#index"
   get "/admin/merchants/:id", to: "admin/merchants#show"
+  get "/admin/merchants/:id/edit", to: "admin/merchants#edit"
+  patch "/admin/merchants/:id", to: "admin/merchants#update"
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -14,5 +14,16 @@ RSpec.describe "/admin/merchants/:id" do
       expect(page).to_not have_content("#{merchant_1.name}")
       expect(page).to_not have_content("#{merchant_3.name}")
     end
+
+    it "displays a link to that takes you to a page to edit the merchants information" do
+      visit "/admin/merchants/#{merchant_2.id}"
+
+      expect(page).to_not have_content("Merchant #{merchant_1.id} has been successfully updated")
+
+      expect(page).to have_link("Edit #{merchant_2.name}")
+      click_link("Edit #{merchant_2.name}")
+
+      expect(current_path).to eq("/admin/merchants/#{merchant_2.id}/edit")
+    end
   end
 end

--- a/spec/features/admin/merchants/update_spec.rb
+++ b/spec/features/admin/merchants/update_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "/admin/merchants/:id/edit" do
+  describe "As an Admin" do
+    let!(:merchant_1) { create(:merchant) }
+
+    it "displays a form to update the merchant, with the merchants existing information" do
+      visit "/admin/merchants/#{merchant_1.id}/edit"
+      expect(page).to have_field("Name:", with: "#{merchant_1.name}")
+      
+      fill_in 'Name:', with: "Busta Rhymes"
+      click_button("Update Merchant")
+      
+      expect(current_path).to eq("/admin/merchants/#{merchant_1.id}")
+      expect(page).to have_content("Busta Rhymes")
+      expect(page).to have_content("Merchant #{merchant_1.id} has been successfully updated")
+    end
+  end
+end


### PR DESCRIPTION
This PR will introduce features that display a link to edit a merchant on the admin merchant show page, when you go to that page, the merchants existing info is already filled out, and once its update you are redirected to the show page where you can see the updated merchant information and a message stating the update was successful.

All features have had testing specs added.