### PR TITLE
Us27 admin merchant enable disable

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -13,7 +13,13 @@ class Admin::MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-    if @merchant.update(merchant_params)
+    if params[:status] == "1"
+      @merchant.update(status: 1)
+      redirect_to "/admin/merchants"
+    elsif params[:status] == "0"
+      @merchant.update(status: 0)
+      redirect_to "/admin/merchants"
+    elsif @merchant.update(merchant_params)
       redirect_to "/admin/merchants/#{@merchant.id}"
       flash[:notice] = "Merchant #{@merchant.id} has been successfully updated"
     else

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,4 +2,14 @@ class Merchant < ApplicationRecord
   has_many :items
   has_many :invoice_items, through: :items
   validates_presence_of :name
+
+  enum status: ["enabled", "disabled"] # enabled = 0, disabled = 1
+
+  def self.filter_enabled
+    Merchant.where(status: "enabled")
+  end
+
+  def self.filter_disabled
+    Merchant.where(status: "disabled")
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,6 +1,17 @@
 <h1>Admin Merchants</h1>
-<div class="admin_merchants">
-  <% @merchants.each do |merchant| %>
+
+<div class="enabled_admin_merchants">
+  <h2>Enabled Merchants</h2>
+  <% @merchants.filter_enabled.each do |merchant| %>
     <%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %>
+    <%= button_to "Disable #{merchant.name}", "/admin/merchants/#{merchant.id}?status=1", method: :patch %>
+  <% end %>
+</div>
+
+<div class="disabled_admin_merchants">
+  <h2>Disabled Merchants</h2>
+  <% @merchants.filter_disabled.each do |merchant| %>
+    <%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %>
+    <%= button_to "Enable #{merchant.name}", "/admin/merchants/#{merchant.id}?status=0", method: :patch %>
   <% end %>
 </div>

--- a/db/migrate/20230603143608_add_status_to_merchants.rb
+++ b/db/migrate/20230603143608_add_status_to_merchants.rb
@@ -1,5 +1,5 @@
 class AddStatusToMerchants < ActiveRecord::Migration[7.0]
   def change
-    add_column :merchants, :status, :string, :default => "enabled"
+    add_column :merchants, :status, :integer, :default => 0
   end
 end

--- a/db/migrate/20230603143608_add_status_to_merchants.rb
+++ b/db/migrate/20230603143608_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merchants, :status, :string, :default => "enabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_02_180154) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_03_143608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_180154) do
     t.string "name"
     t.string "created_at"
     t.string "updated_at"
+    t.string "status", default: "enabled"
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_143608) do
     t.string "name"
     t.string "created_at"
     t.string "updated_at"
-    t.string "status", default: "enabled"
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :merchant do
     name {Faker::Company.name}
+    status { rand(0..1) }
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -29,5 +29,41 @@ RSpec.describe "/admin/merchants" do
 
       expect(current_path).to eq("/admin/merchants/#{merchant_2.id}")
     end
+
+    it "displays a button next to each merchant to enable or disable the merchant" do
+      visit "/admin/merchants"
+
+      within ".enabled_admin_merchants" do
+        expect(page).to have_link("#{merchant_1.name}")
+        expect(page).to have_link("#{merchant_2.name}")
+        expect(page).to have_link("#{merchant_3.name}")
+        
+        expect(page).to have_button("Disable #{merchant_1.name}")
+        expect(page).to have_button("Disable #{merchant_2.name}")
+        expect(page).to have_button("Disable #{merchant_3.name}")
+
+        click_button("Disable #{merchant_1.name}")
+      end
+
+      expect(current_path).to eq("/admin/merchants")
+
+      within ".enabled_admin_merchants" do
+        expect(page).to have_link("#{merchant_2.name}")
+        expect(page).to have_link("#{merchant_3.name}")
+        
+        expect(page).to have_button("Disable #{merchant_2.name}")
+        expect(page).to have_button("Disable #{merchant_3.name}")
+      end
+
+      within ".disabled_admin_merchants" do
+        expect(page).to have_link("#{merchant_1.name}")
+        
+        expect(page).to have_button("Enable #{merchant_1.name}")
+      end
+
+      expect(merchant_1.status).to eq("disabled")
+      expect(merchant_2.status).to eq("enabled")
+      expect(merchant_3.status).to eq("enabled")
+    end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "/admin/merchants" do
   describe "as an admin" do
-    let!(:merchant_1) { create(:merchant) }
-    let!(:merchant_2) { create(:merchant) }
-    let!(:merchant_3) { create(:merchant) }
+    let!(:merchant_1) { create(:merchant, status: 0) }
+    let!(:merchant_2) { create(:merchant, status: 0) }
+    let!(:merchant_3) { create(:merchant, status: 0) }
 
     it "displays the name of each merchant in the system" do
       visit "/admin/merchants"
 
-      within ".admin_merchants" do
+      within ".enabled_admin_merchants" do
         expect(page).to have_content("#{merchant_1.name}")
         expect(page).to have_content("#{merchant_2.name}")
         expect(page).to have_content("#{merchant_3.name}")
@@ -19,7 +19,7 @@ RSpec.describe "/admin/merchants" do
     it "displays a link to each of the merchants on the admin merchants index page" do
       visit "/admin/merchants"
 
-      within ".admin_merchants" do
+      within ".enabled_admin_merchants" do
         expect(page).to have_link("#{merchant_1.name}")
         expect(page).to have_link("#{merchant_2.name}")
         expect(page).to have_link("#{merchant_3.name}")
@@ -48,22 +48,26 @@ RSpec.describe "/admin/merchants" do
       expect(current_path).to eq("/admin/merchants")
 
       within ".enabled_admin_merchants" do
+        expect(page).to have_content("Enabled Merchants")
+        expect(page).to_not have_link("#{merchant_1.name}")
         expect(page).to have_link("#{merchant_2.name}")
         expect(page).to have_link("#{merchant_3.name}")
         
+        expect(page).to_not have_button("Disable #{merchant_1.name}")
         expect(page).to have_button("Disable #{merchant_2.name}")
         expect(page).to have_button("Disable #{merchant_3.name}")
       end
 
       within ".disabled_admin_merchants" do
+        expect(page).to have_content("Disabled Merchants")
         expect(page).to have_link("#{merchant_1.name}")
-        
-        expect(page).to have_button("Enable #{merchant_1.name}")
-      end
+        expect(page).to_not have_link("#{merchant_2.name}")
+        expect(page).to_not have_link("#{merchant_3.name}")
 
-      expect(merchant_1.status).to eq("disabled")
-      expect(merchant_2.status).to eq("enabled")
-      expect(merchant_3.status).to eq("enabled")
+        expect(page).to have_button("Enable #{merchant_1.name}")
+        expect(page).to_not have_button("Disable #{merchant_2.name}")
+        expect(page).to_not have_button("Disable #{merchant_3.name}")
+      end
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,9 +11,28 @@ RSpec.describe Merchant, type: :model do
   end
 
   before(:each) do 
-    @merchant = create(:merchant)
+    @merchant_1 = create(:merchant, status: 0)
+    @merchant_2 = create(:merchant, status: 0)
+    @merchant_3 = create(:merchant, status: 1)
   end
 
+  describe "#class methods" do
+    it "can filter records by enabled" do
+      original = [@merchant_1, @merchant_2, @merchant_3]
+      expected = [@merchant_1, @merchant_2]
+
+      expect(Merchant.all).to eq(original)
+      expect(Merchant.filter_enabled).to eq(expected)
+    end
+
+    it "can filter records by disabled" do
+      original = [@merchant_1, @merchant_2, @merchant_3]
+      expected = [@merchant_3]
+
+      expect(Merchant.all).to eq(original)
+      expect(Merchant.filter_disabled).to eq(expected)
+    end
+  end
 end
 
 


### PR DESCRIPTION
This PR will add a status column to the Merchants table AND features to the Admin Merchants Index page to enable and disable merchants. When you click enable or disable it updates the merchants status and moves it into the requisite section. It also adds two class methods to the merchants model, for filtering by enabled/disabled status.

All testing specs added for models and features.