### PR TITLE
Us34 invoice show page item info

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def format_price(price)
+    number_to_currency(price, unit: "$", separator: ".", delimiter: "")
+  end
+
+  def formatted_time
+    to_datetime.strftime("%A, %B %d, %Y")
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,3 +2,21 @@
 <p>Status: <%= @invoice.status %></p>
 <p>Created on: <%= @invoice.formatted_time %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
+<section id="item_table">
+  <h2>Items on Invoice</h2>
+  <table>
+    <tr>
+      <th>Item</th>
+      <th>Quantity</th>
+      <th>Unit Price</th>
+      <th>Status</th>
+    </tr>
+    <% @invoice.invoice_items.each do |invoice_item| %>
+      <tr>
+        <td><%= invoice_item.item.name %></td>
+        <td><%= invoice_item.quantity %></td>
+        <td><%= format_price(invoice_item.unit_price) %></td>
+        <td><%= invoice_item.status %></td>
+      </tr>
+    </section>
+  <% end %>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,12 +1,28 @@
 require "rails_helper"
+require "application_helper"
 
 RSpec.describe "Admin Invoices Show Page" do
   before(:each) do
     @customer1 = create(:customer)
     @customer2 = create(:customer)
 
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+
     @invoice_1 = create(:invoice, customer_id: @customer1.id)
     @invoice_2 = create(:invoice, customer_id: @customer2.id)
+
+    @item_1 = create(:item, merchant_id: @merchant_1.id)
+    @item_2 = create(:item, merchant_id: @merchant_1.id)
+    @item_3 = create(:item, merchant_id: @merchant_1.id)
+    @item_4 = create(:item, merchant_id: @merchant_2.id)
+    @item_5 = create(:item, merchant_id: @merchant_2.id)
+
+    @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id)
+    @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id)
+    @invoice_item_3 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_3.id)
+    @invoice_item_4 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_4.id)
+    @invoice_item_5 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_5.id)
   end
 
   describe "As an admin" do
@@ -19,10 +35,37 @@ RSpec.describe "Admin Invoices Show Page" do
       expect(page).to have_content("Customer: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
 
       expect(page).to_not have_content(@invoice_2.id)
-      expect(page).to_not have_content(@invoice_2.status)
-      expect(page).to_not have_content(@invoice_2.formatted_time)
       expect(page).to_not have_content(@invoice_2.customer.first_name)
       expect(page).to_not have_content(@invoice_2.customer.last_name)
+    end
+
+    it "displays all items on the invoice" do
+      visit "/admin/invoices/#{@invoice_1.id}"
+
+      within("#item_table") do
+        expect(page).to have_content("Items on Invoice")
+        expect(page).to have_content("#{@invoice_1.items[0].name}")
+        expect(page).to have_content("#{@invoice_1.items[1].name}")
+        expect(page).to have_content("#{@invoice_1.items[2].name}")
+
+        expect(page).to_not have_content("#{@invoice_2.items[0].name}")
+        expect(page).to_not have_content("#{@invoice_2.items[1].name}")
+
+        expect(page).to have_content("#{@invoice_item_1.quantity}")
+        expect(page).to have_content("#{@invoice_item_2.quantity}")
+        expect(page).to have_content("#{@invoice_item_3.quantity}")
+
+        expect(page).to have_content("$#{sprintf('%.2f', @invoice_item_1.unit_price)}")
+        expect(page).to have_content("$#{sprintf('%.2f', @invoice_item_2.unit_price)}")
+        expect(page).to have_content("$#{sprintf('%.2f', @invoice_item_3.unit_price)}")
+
+        expect(page).to_not have_content("$#{sprintf('%.2f', @invoice_item_4.unit_price)}")
+        expect(page).to_not have_content("$#{sprintf('%.2f', @invoice_item_5.unit_price)}")
+
+        expect(page).to have_content("#{@invoice_item_1.status}")
+        expect(page).to have_content("#{@invoice_item_2.status}")
+        expect(page).to have_content("#{@invoice_item_3.status}")
+      end
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -18,12 +18,4 @@ RSpec.describe Invoice, type: :model do
     @merchant = create(:merchant)
     @invoice = create(:invoice, customer_id: @customer.id)
   end
-
-  describe "instance methods" do
-    describe "#formatted_time" do
-      it "returns the time formatted" do
-        expect(@invoice.formatted_time).to eq(@invoice.created_at.to_datetime.strftime("%A, %B %d, %Y"))
-      end
-    end
-  end
 end


### PR DESCRIPTION
Completes User Story 34 Admin Invoice Show Page item info
This adds a table to an Admin/Invoice/ show page that displays all items purchased on that invoice as well as their name, quantity ordered, price, and status of the invoice. 