### PR TITLE
Us29 admin merchants create

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -3,6 +3,20 @@ class Admin::MerchantsController < ApplicationController
     @merchants = Merchant.all
   end
 
+  def new
+    @merchant = Merchant.new
+  end
+
+  def create
+    merchant = Merchant.new(merchant_params)
+    if merchant.save
+      redirect_to "/admin/merchants"
+    else
+      redirect_to "/admin/merchants/new"
+      flash[:alert] = "Error: #{error_message(merchant.errors)}"
+    end
+  end
+
   def show
     @merchant = Merchant.find(params[:id])
   end
@@ -22,8 +36,6 @@ class Admin::MerchantsController < ApplicationController
     elsif @merchant.update(merchant_params)
       redirect_to "/admin/merchants/#{@merchant.id}"
       flash[:notice] = "Merchant #{@merchant.id} has been successfully updated"
-    else
-      redirect_to "/admin/merchants/#{@merchant.id}/edit"
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::Base
   def welcome
   end
+
+  private
+
+  def error_message(errors)
+    errors.full_messages.join(', ')
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,5 +1,9 @@
 <h1>Admin Merchants</h1>
 
+<%= link_to "Create New Merchant", "/admin/merchants/new", method: :get %>
+
+
+
 <div class="enabled_admin_merchants">
   <h2>Enabled Merchants</h2>
   <% @merchants.filter_enabled.each do |merchant| %>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,0 +1,7 @@
+<h1>Create New Merchant</h1>
+
+<%= form_with model: @merchant, url: "/admin/merchants", method: :post, local: true do |form| %>
+  <%= form.label :name, "Name:" %>
+  <%= form.text_field :name %>
+  <%= form.submit "Submit" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,11 @@
   </head>
 
   <body>
+    <% flash.each do |type, msg| %>
+      <div id="flash-messages">
+        <%= msg %>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get "merchants/:id/invoices", to: "merchants/invoices#index"
 
   get "/admin/merchants", to: "admin/merchants#index"
+  get "/admin/merchants/new", to: "admin/merchants#new"
+  post "/admin/merchants", to: "admin/merchants#create"
   get "/admin/merchants/:id", to: "admin/merchants#show"
   get "/admin/merchants/:id/edit", to: "admin/merchants#edit"
   patch "/admin/merchants/:id", to: "admin/merchants#update"

--- a/db/migrate/20230603143608_add_status_to_merchants.rb
+++ b/db/migrate/20230603143608_add_status_to_merchants.rb
@@ -1,5 +1,5 @@
 class AddStatusToMerchants < ActiveRecord::Migration[7.0]
   def change
-    add_column :merchants, :status, :integer, :default => 0
+    add_column :merchants, :status, :integer, :default => 1
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_143608) do
     t.string "name"
     t.string "created_at"
     t.string "updated_at"
-    t.integer "status", default: 0
+    t.integer "status", default: 1
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "/admin/merchants" do
     let!(:merchant_1) { create(:merchant, status: 0) }
     let!(:merchant_2) { create(:merchant, status: 0) }
     let!(:merchant_3) { create(:merchant, status: 0) }
+    let!(:merchant_4) { create(:merchant, status: 1) }
 
     it "displays the name of each merchant in the system" do
       visit "/admin/merchants"
@@ -68,6 +69,40 @@ RSpec.describe "/admin/merchants" do
         expect(page).to_not have_button("Disable #{merchant_2.name}")
         expect(page).to_not have_button("Disable #{merchant_3.name}")
       end
+    end
+
+    it "can update from enabled to disabled" do
+      visit "/admin/merchants"
+
+      within ".disabled_admin_merchants" do
+        expect(page).to have_link("#{merchant_4.name}")
+        
+        expect(page).to have_button("Enable #{merchant_4.name}")
+
+        click_button("Enable #{merchant_4.name}")
+      end
+
+      within ".enabled_admin_merchants" do
+        expect(page).to have_link("#{merchant_4.name}")
+        
+        expect(page).to have_button("Disable #{merchant_4.name}")
+
+        click_button("Disable #{merchant_4.name}")
+      end
+    end
+
+    it "displays a link to create a new merchant" do
+      visit "/admin/merchants"
+
+      expect(page).to have_link("Create New Merchant")
+    end
+
+    it "the link takes me to a new page to create a merchant" do
+      visit "/admin/merchants"
+
+      click_link("Create New Merchant")
+
+      expect(current_path).to eq("/admin/merchants/new")
     end
   end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "/admin/merchants/new" do
+  describe "As an Admin" do
+    let!(:merchant_1) { create(:merchant, status: 0) }
+
+    it "displays a form to create a new merchant" do
+      visit "/admin/merchants/new"
+
+      expect(page).to have_field("Name:")
+      fill_in("Name:", with: "Busta Rhymes")
+      click_button("Submit")
+
+      expect(current_path).to eq("/admin/merchants")
+
+      within ".enabled_admin_merchants" do
+        expect(page).to have_content("#{merchant_1.name}")
+        expect(page).to_not have_content("Busta Rhymes")
+      end
+
+      within ".disabled_admin_merchants" do
+        expect(page).to_not have_content("#{merchant_1.name}")
+        expect(page).to have_content("Busta Rhymes")
+      end
+    end
+
+    it "can display error messages if fields are not filled out" do
+      visit "/admin/merchants/new"
+
+      click_button("Submit")
+
+      expect(current_path).to eq("/admin/merchants/new")
+      expect(page).to have_content("Name can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
This PR will add features for Admin Merchants Index page to create a new merchant. It is able to display an error message if information is not fully filled out. New merchant is also created with default status of disabled.

All testing specs added.