### PR TITLE
Us16 invoice item info

### DIFF
--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -4,3 +4,21 @@
   <p>Created on: <%= @invoice.created_at.to_datetime.strftime("%A, %B %d, %Y") %></p>
   <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 </section>
+<section id="item_table">
+  <h2>Items on Invoice</h2>
+  <table>
+    <tr>
+      <th>Item</th>
+      <th>Quantity</th>
+      <th>Unit Price</th>
+      <th>Status</th>
+    </tr>
+    <% @invoice.invoice_items.each do |invoice_item| %>
+      <tr>
+        <td><%= invoice_item.item.name %></td>
+        <td><%= invoice_item.quantity %></td>
+        <td><%= number_to_currency(invoice_item.unit_price, unit: "$", separator: ".", delimiter: "") %></td>
+        <td><%= invoice_item.status %></td>
+      </tr>
+    </section>
+  <% end %>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -34,5 +34,34 @@ RSpec.describe "Merchant Invoices Show Page" do
         expect(page).to have_content("Customer: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
       end
     end
+
+    it "displays all items on the invoice and their info" do
+      visit "/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}"
+# save_and_open_page
+      within("#item_table") do
+        expect(page).to have_content("Items on Invoice")
+        expect(page).to have_content("#{@invoice_1.items[0].name}")
+        expect(page).to have_content("#{@invoice_1.items[1].name}")
+        expect(page).to have_content("#{@invoice_1.items[2].name}")
+
+        expect(page).to_not have_content("#{@invoice_2.items[0].name}")
+        expect(page).to_not have_content("#{@invoice_2.items[1].name}")
+
+        expect(page).to have_content("#{@invoice_item_1.quantity}")
+        expect(page).to have_content("#{@invoice_item_2.quantity}")
+        expect(page).to have_content("#{@invoice_item_3.quantity}")
+
+        expect(page).to have_content("$#{sprintf('%.2f', @invoice_item_1.unit_price)}")
+        expect(page).to have_content("$#{sprintf('%.2f', @invoice_item_2.unit_price)}")
+        expect(page).to have_content("$#{sprintf('%.2f', @invoice_item_3.unit_price)}")
+
+        expect(page).to_not have_content("$#{sprintf('%.2f', @invoice_item_4.unit_price)}")
+        expect(page).to_not have_content("$#{sprintf('%.2f', @invoice_item_5.unit_price)}")
+
+        expect(page).to have_content("#{@invoice_item_1.status}")
+        expect(page).to have_content("#{@invoice_item_2.status}")
+        expect(page).to have_content("#{@invoice_item_3.status}")
+      end
+    end
   end
 end


### PR DESCRIPTION
This completes User Story 16 Merchant Invoice Show Page: Invoice Item Information
This adds a table to the merchants invoice show page that has all items on the invoice along with their information