### PR TITLE
Us31 admin merchants best day

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -31,4 +31,9 @@ class Merchant < ApplicationRecord
   def unique_invoices
     self.invoices.distinct
   end
+
+  def best_day
+    day = invoice_items.joins(invoice: :transactions).select('invoices.*, sum(invoice_items.quantity * invoice_items.unit_price) AS revenue').where('transactions.result = 0').group('invoices.id').order('revenue desc').limit(1).first.created_at
+    day.to_datetime.strftime("%Y-%m-%d")
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -22,8 +22,8 @@
 
 <div class="admin_top_merchants_by_revenue">
 <h2>Top Merchants</h2>
-<% counter = 1 %>
+<ol>
 <% @merchants.top_5_by_revenue.each do |merchant| %>
-  <p><%= "#{counter}. "%> <%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %> <%=" - #{number_to_currency(merchant.revenue / 100, unit: "$", separator: ".", delimiter: ",")} in sales" %></p>
-  <% counter += 1 %>
+  <li><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %> <%=" - #{number_to_currency(merchant.revenue / 100, unit: "$", separator: ".", delimiter: ",")} in sales" %></li>
+  <p><%= "Top Day for #{merchant.name} was #{merchant.best_day}" %></p>
 <% end %>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -226,5 +226,24 @@ RSpec.describe "/admin/merchants" do
         expect(page).to_not have_link("#{merchant_3.name}")
       end
     end
+
+    it "displays the top 5 merchants best day of revenue with a label" do
+
+      visit "/admin/merchants"
+
+      within ".admin_top_merchants_by_revenue" do
+        expect(page).to have_link("#{merchant_1.name}")
+        expect(page).to have_content("Top Day for #{merchant_1.name} was 2023-06-06")
+        expect(page).to have_link("#{merchant_2.name}")
+        expect(page).to have_content("Top Day for #{merchant_2.name} was 2023-06-06")
+        expect(page).to have_link("#{merchant_4.name}")
+        expect(page).to have_content("Top Day for #{merchant_4.name} was 2023-06-06")
+        expect(page).to have_link("#{merchant_5.name}")
+        expect(page).to have_content("Top Day for #{merchant_5.name} was 2023-06-06")
+        expect(page).to have_link("#{merchant_6.name}")
+        expect(page).to have_content("Top Day for #{merchant_6.name} was 2023-06-06")
+        save_and_open_page
+      end
+    end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -242,7 +242,6 @@ RSpec.describe "/admin/merchants" do
         expect(page).to have_content("Top Day for #{merchant_5.name} was 2023-06-06")
         expect(page).to have_link("#{merchant_6.name}")
         expect(page).to have_content("Top Day for #{merchant_6.name} was 2023-06-06")
-        save_and_open_page
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Merchant, type: :model do
     describe "#top_5_customers" do
       it "merchant can find number of successfull customer transactions" do
         have = [customer_2, customer_4, customer_1, customer_3, customer_5]
-        not_have= ([customer_6, customer_7])
+        not_have= [customer_6, customer_7]
         expect(@merchant_4.top_5_customers).to eq(have)
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe Merchant, type: :model do
       let!(:invoice_14) { create(:invoice, customer_id: customer_5.id, status: 1) }
       let!(:invoice_15) { create(:invoice, customer_id: customer_5.id, status: 1) }
 
-      let!(:invoice_16) { create(:invoice, customer_id: customer_6.id, status: 1) }
-      let!(:invoice_17) { create(:invoice, customer_id: customer_6.id, status: 1) }
-      let!(:invoice_18) { create(:invoice, customer_id: customer_6.id, status: 1) }
+      let!(:invoice_16) { create(:invoice, customer_id: customer_6.id, status: 1, created_at: "2023-05-20 07:45:12.82345") }
+      let!(:invoice_17) { create(:invoice, customer_id: customer_6.id, status: 1, created_at: "2023-03-06 01:49:45.21235") }
+      let!(:invoice_18) { create(:invoice, customer_id: customer_6.id, status: 1, created_at: "2023-01-05 21:16:07.11835") }
 
       let!(:invoice_item_1) { create(:invoice_item, invoice: invoice_1, item: item_1, unit_price: 100000, quantity: 1) }
       let!(:invoice_item_2) { create(:invoice_item, invoice: invoice_2, item: item_2, unit_price: 100000, quantity: 1) }
@@ -119,6 +119,7 @@ RSpec.describe Merchant, type: :model do
       let!(:invoice_item_16) { create(:invoice_item, invoice: invoice_16, item: item_16, unit_price: 500000, quantity: 1) }
       let!(:invoice_item_17) { create(:invoice_item, invoice: invoice_17, item: item_17, unit_price: 500000, quantity: 1) }
       let!(:invoice_item_18) { create(:invoice_item, invoice: invoice_18, item: item_18, unit_price: 500000, quantity: 1) }
+      let!(:invoice_item_19) { create(:invoice_item, invoice: invoice_18, item: item_18, unit_price: 500000, quantity: 1) }
 
       let!(:transaction_1) { create(:transaction, invoice: invoice_1, result: 0) }
       let!(:transaction_2) { create(:transaction, invoice: invoice_2, result: 0) }
@@ -145,6 +146,10 @@ RSpec.describe Merchant, type: :model do
 
         expect(Merchant.all).to eq(original)
         expect(Merchant.top_5_by_revenue).to eq(expected)
+      end
+
+      it "can return a single merchants best day in revenue" do
+        expect(merchant_6.best_day).to eq(invoice_18.created_at.to_datetime.strftime("%Y-%m-%d"))
       end
     end
   end


### PR DESCRIPTION
This PR will introduce a feature that displays the best day of sale for the admin merchants top 5 merchants. It includes a new model instance method for merchant that returns the best day of revenue for that merchant.

All features and models have been tested.