### PR TITLE
Us18 update item status

### DIFF
--- a/app/controllers/invoice_items_controller.rb
+++ b/app/controllers/invoice_items_controller.rb
@@ -1,0 +1,13 @@
+class InvoiceItemsController < ApplicationController
+  def update
+    invoice_item = InvoiceItem.find(params[:id])
+    invoice_item.update(invoice_params)
+    redirect_to "/merchants/#{invoice_item.item[:merchant_id]}/invoices/#{invoice_item[:invoice_id]}"
+  end
+
+  private
+
+  def invoice_params
+    params.permit(:status)
+  end
+end

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -19,7 +19,12 @@
         <td><%= invoice_item.item.name %></td>
         <td><%= invoice_item.quantity %></td>
         <td><%= number_to_currency(invoice_item.unit_price, unit: "$", separator: ".", delimiter: "") %></td>
-        <td><%= invoice_item.status %></td>
+        <td><%= form_with url: "/invoice_items/#{invoice_item.id}", method: :patch, id: "item-#{invoice_item.item.id}-Status" do |form|  %>
+            <%= form.label :item_status %>
+            <%= form.select :status, options_for_select(["packaged", "shipped", "pending"], invoice_item.status) %>
+            <%= form.submit "Update Item Status" %>
+            <% end %>
+          </td>
       </tr>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   get "/merchants/:id/invoices", to: "merchants/invoices#index"
   get "/merchants/:id/invoices/:id", to: "merchants/invoices#show"
 
+  patch "/invoice_items/:id", to: "invoice_items#update"
+
   get "/admin", to: "admin/dashboards#welcome"
 
   get "/admin/merchants", to: "admin/merchants#index"

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -233,15 +233,15 @@ RSpec.describe "/admin/merchants" do
 
       within ".admin_top_merchants_by_revenue" do
         expect(page).to have_link("#{merchant_1.name}")
-        expect(page).to have_content("Top Day for #{merchant_1.name} was 2023-06-06")
+        expect(page).to have_content("Top Day for #{merchant_1.name} was #{merchant_1.best_day}")
         expect(page).to have_link("#{merchant_2.name}")
-        expect(page).to have_content("Top Day for #{merchant_2.name} was 2023-06-06")
+        expect(page).to have_content("Top Day for #{merchant_2.name} was #{merchant_2.best_day}")
         expect(page).to have_link("#{merchant_4.name}")
-        expect(page).to have_content("Top Day for #{merchant_4.name} was 2023-06-06")
+        expect(page).to have_content("Top Day for #{merchant_4.name} was #{merchant_4.best_day}")
         expect(page).to have_link("#{merchant_5.name}")
-        expect(page).to have_content("Top Day for #{merchant_5.name} was 2023-06-06")
+        expect(page).to have_content("Top Day for #{merchant_5.name} was #{merchant_5.best_day}")
         expect(page).to have_link("#{merchant_6.name}")
-        expect(page).to have_content("Top Day for #{merchant_6.name} was 2023-06-06")
+        expect(page).to have_content("Top Day for #{merchant_6.name} was #{merchant_6.best_day}")
       end
     end
   end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -76,5 +76,30 @@ RSpec.describe "Merchant Invoices Show Page" do
         expect(page).to have_content("Revenue: $#{sprintf('%.2f', @invoice_2.revenue)}")
       end
     end
+
+    describe "Admin Invoice Show Page - Update Invoice Status" do
+      it "displays a select field to update the invoice status" do
+        visit "/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}"
+
+        within "#item-#{@invoice_item_1.item.id}-Status" do
+          expect(page).to have_select("status", selected: "#{@invoice_item_1.status}")
+          expect(page).to have_button("Update Item Status")
+        end
+      end
+
+      it "updates the invoice status when a new status is selected" do
+        visit "/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}"
+
+        within "#item-#{@invoice_item_1.item.id}-Status" do
+          select "shipped", from: "status"
+          click_button "Update Item Status"
+        end
+
+        @invoice_item_1.reload
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}")
+        expect(@invoice_item_1.status).to eq("shipped")
+
+      end
+    end
   end
 end


### PR DESCRIPTION
This completes US18 Update Item Status
This adds a select box next to a merchants invoice item to change the status of the item

I also refactored some tests on admin/merchants/index_spec to make it more dynamic