### PR TITLE
Us4/5 active disable coupon

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -10,6 +10,7 @@ class CouponsController < ApplicationController
 
   def show
     @coupon = Coupon.find(params[:id])
+    @merchant = Merchant.find(@coupon.merchant_id)
   end
 
   def create
@@ -23,6 +24,20 @@ class CouponsController < ApplicationController
     else
       redirect_to new_merchant_coupon_path(@merchant)
       flash[:alert] = "Please fill out all fields"
+    end
+  end
+
+  def update
+    coupon = Coupon.find(params[:id])
+    if params[:status] == "0"
+      coupon.update(status: 0)
+      redirect_to merchant_coupon_path(coupon.merchant_id, coupon)
+    elsif params[:status] == "1"
+      coupon.update(status: 1)
+      redirect_to merchant_coupon_path(coupon.merchant_id, coupon)
+    else
+      coupon.update(coupon_params)
+      redirect_to merchant_coupon_path(coupon.merchant_id, coupon)
     end
   end
 

--- a/app/views/coupons/show.html.erb
+++ b/app/views/coupons/show.html.erb
@@ -4,3 +4,8 @@
 <p>Coupon Type: <%= @coupon.coupon_type %></p>
 <p>Times Used: <%= @coupon.uses %></p>
 <p>Status: <%= @coupon.status %></p>
+<% if @coupon.status == "activated" %>
+  <p><%= button_to "Disable Coupon", "/merchants/#{@merchant.id}/coupons/#{@coupon.id}?status=0", method: :patch %></p>
+<% else %>
+  <p><%= button_to "Activate Coupon", "/merchants/#{@merchant.id}/coupons/#{@coupon.id}?status=1", method: :patch %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   resources :merchants do
     resources :items, only: [:index, :show, :new, :create, :edit, :update], controller: "merchants/items"
     resources :invoices, only: [:index, :show], controller: "merchants/invoices"
-    resources :coupons, only: [:index, :show, :new, :create], controller: "coupons"
+    resources :coupons, only: [:index, :show, :new, :create, :edit, :update], controller: "coupons"
   end
 
   resources :invoice_items, only: [:update]

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Coupons Show Page" do
   before(:each) do
     @merchant_1 = create(:merchant)
     @coupon_1 = @merchant_1.coupons.create!(code: "20OFF", name: "Summer Sale", status: 0, value: 20, coupon_type: 1)
+    @coupon_2 = @merchant_1.coupons.create!(code: "15OFF", name: "Winter Sale", status: 0, value: 15, coupon_type: 1)
     @customer_1 = create(:customer)
 
     @invoice_1 = create(:invoice, status: 2, coupon_id: @coupon_1.id, customer_id: @customer_1.id)
@@ -21,6 +22,36 @@ RSpec.describe "Coupons Show Page" do
       expect(page).to have_content("Coupon Type: #{@coupon_1.coupon_type}")
       expect(page).to have_content("Status: #{@coupon_1.status}")
       expect(page).to have_content("Times Used: #{@coupon_1.uses}")
+
+      expect(page).to_not have_content("Coupon Name: #{@coupon_2.name}")
+      expect(page).to_not have_content("Code: #{@coupon_2.code}")
+    end
+
+    it "has a button to disable the coupon" do
+      @coupon_1.update(status: 1)
+      visit merchant_coupon_path(@merchant_1, @coupon_1)
+
+      expect(page).to have_content("Status: activated")
+      expect(page).to have_button("Disable Coupon")
+
+      click_button "Disable Coupon"
+
+      expect(current_path).to eq(merchant_coupon_path(@merchant_1, @coupon_1))
+      expect(page).to have_content("Status: disabled")
+      expect(page).to have_button("Activate Coupon")
+    end
+
+    it "has a button to activate the coupon" do
+      visit merchant_coupon_path(@merchant_1, @coupon_2)
+
+      expect(page).to have_content("Status: disabled")
+      expect(page).to have_button("Activate Coupon")
+
+      click_button "Activate Coupon"
+
+      expect(current_path).to eq(merchant_coupon_path(@merchant_1, @coupon_2))
+      expect(page).to have_content("Status: activated")
+      expect(page).to have_button("Disable Coupon")
     end
   end
 end


### PR DESCRIPTION
This completes User Stories 4 and 5 Activate/Disable coupon Buttons
The functionality between these 2 were very similar that it made sense to put them on the same branch. It adds a button under each coupon on their show page to either 'activate' or 'disable' the coupon depending on their current status.